### PR TITLE
Adiciona suporte a imagens com multi arquiteturas

### DIFF
--- a/imagens/Makefile
+++ b/imagens/Makefile
@@ -3,10 +3,13 @@ help: ## Mostrando o help
 
 all: debian-inf534 alpine-bind ## Criando todas as imagens necessarias para inf534
 
-debian-inf534: ## Criando a imagem para container da disciplina inf534 baseado em debian
-	docker build -t sidneypio/debian-inf534:latest . -f Dockerfile-debian-inf534 
+debian-inf534-multi-arch: ## Criando a imagem para container da disciplina inf534 baseado em debian para arm64/v8 e amd64
+	docker buildx build --platform linux/arm64/v8,linux/amd64 --tag sidneypio/debian-inf534:latest --push . -f Dockerfile-debian-inf534
 
-alpine-bind: ## Criando a imagem para container bind da disciplina inf534 
+debian-inf534: ## Criando a imagem para container da disciplina inf534 baseado em debian para amd64
+	docker build -t sidneypio/debian-inf534:latest . -f Dockerfile-debian-inf534
+
+alpine-bind: ## Criando a imagem para container bind da disciplina inf534
 	docker build -t sidneypio/alpine-bind:latest . -f Dockerfile-alpine-bind
 
 push: ## Envia as imagens para o Docker Hub (opcional)

--- a/imagens/README.md
+++ b/imagens/README.md
@@ -11,6 +11,13 @@
 * Tradicionalmente instalamos apenas 1 unico servico no docker, mas optei por fazer simplificar a compreensao. Em producao, usem apenas 1 servico, simplificando o gerenciamento e atualizações.
 * Para o servidor de DNS, criamos uma imagem utilizando como base o "Alpine Linux" e rodando apenas o "servidor bind (dns)"
 
+## Criando imagens com suporte à múltiplas arquiteturas
+
+O comando `debian-inf534-multi-arch` irá usar o [docker buildx](https://docs.docker.com/engine/reference/commandline/buildx/) para fazer o build da imagem
+para múltiplas arquiteturas de processamento (atualmente para amd64/v8 e arm64); além disso, este comando irá fazer a publicação das imagens 
+de forma automática no repositório configurado. A flag `--platform` pode ser atualizada para a inclusão de outras 
+arquiteturas caso seja necessário no futuro.
+
 # Comando para enviar para o dockerhub
 Apenas para quem deseja continuar o desenvolvimento das imagens e compartilhar com outras pessoas.
 

--- a/lab-inf534/docker-compose.yml
+++ b/lab-inf534/docker-compose.yml
@@ -54,7 +54,7 @@ services:
             - ./conf/roteador/inicio.sh:/usr/local/bin/inicio.sh
         networks:
             redeCliente: # eth0
-                ipv4_address: 10.10.10.100  
+                ipv4_address: 10.10.10.100
                 ipv6_address: 2001:db8:2021:10::100
             redeR1R2: #eth1
                 ipv4_address: 10.10.50.10
@@ -73,7 +73,7 @@ services:
                 ipv4_address: 10.10.50.20
                 ipv6_address: 2001:db8:2021:50::20
             redeServidor: #eth1
-                ipv4_address: 10.10.100.100 
+                ipv4_address: 10.10.100.100
                 ipv6_address: 2001:db8:2021:100::100
 
     web:
@@ -84,13 +84,13 @@ services:
         volumes:
             - ./home/web:/home
             - ./conf/web/etc_nginx:/etc/nginx
-            - ./conf/web/var_html:/var/www/  
-            - ./conf/resolv.conf:/etc/resolv.conf        
+            - ./conf/web/var_html:/var/www/
+            - ./conf/resolv.conf:/etc/resolv.conf
             - ./conf/web/inicio.sh:/usr/local/bin/inicio.sh
         networks:
             redeServidor:
-                ipv4_address: 10.10.100.10 
-                ipv6_address: 2001:db8:2021:100::10 
+                ipv4_address: 10.10.100.10
+                ipv6_address: 2001:db8:2021:100::10
 
     ftp:
         image: sidneypio/debian-inf534
@@ -104,10 +104,10 @@ services:
             - ./conf/ftp/inicio.sh:/usr/local/bin/inicio.sh
         networks:
             redeServidor:
-                ipv4_address: 10.10.100.20 
-                ipv6_address: 2001:db8:2021:100::20 
-    
-   
+                ipv4_address: 10.10.100.20
+                ipv6_address: 2001:db8:2021:100::20
+
+
     ssh:
         image: sidneypio/debian-inf534
         container_name: ssh
@@ -120,8 +120,8 @@ services:
             - ./conf/ssh/inicio.sh:/usr/local/bin/inicio.sh
         networks:
             redeServidor:
-                ipv4_address: 10.10.100.30 
-                ipv6_address: 2001:db8:2021:100::30 
+                ipv4_address: 10.10.100.30
+                ipv6_address: 2001:db8:2021:100::30
 
     dns:
         image: sidneypio/alpine-bind
@@ -136,8 +136,8 @@ services:
             - ./conf/dns/inicio.sh:/usr/local/bin/inicio.sh
         networks:
             redeServidor:
-                ipv4_address: 10.10.100.40 
-                ipv6_address: 2001:db8:2021:100::40            
+                ipv4_address: 10.10.100.40
+                ipv6_address: 2001:db8:2021:100::40
 
 networks:
     redeCliente:


### PR DESCRIPTION
Adiciona novo comando no makefile das imagens para fazer o build e publicação de imagens do debian-inf534 para múltiplas arquiteturas de processadores. Este comando utiliza o [docker buildx](https://docs.docker.com/engine/reference/commandline/buildx/) para tal. Caso seja necessário, é possível adicionar o suporte a outras a arquiteturas apenas adicionando a mesma na flag `--platform` do novo comando.

Esta alteração adiciona o suporte à `amd64` e `arm64/v8`, tornando possível a execução dos containers do laboratório em dispositivos como o `raspberry pi`.